### PR TITLE
fixed: 'type' does not exist on type 'Node'

### DIFF
--- a/docs/walkthroughs/03-defining-custom-elements.md
+++ b/docs/walkthroughs/03-defining-custom-elements.md
@@ -177,6 +177,7 @@ Now, if you press ``Ctrl-``` the block your cursor is in should turn into a code
 But we forgot one thing. When you hit ``Ctrl-``` again, it should change the code block back into a paragraph. To do that, we'll need to add a bit of logic to change the type we set based on whether any of the currently selected blocks are already a code block:
 
 ```jsx
+import { Editor, Transforms, Element } from 'slate'
 const App = () => {
   const editor = useMemo(() => withReact(createEditor()), [])
   const [value, setValue] = useState([
@@ -204,7 +205,7 @@ const App = () => {
             event.preventDefault()
             // Determine whether any of the currently selected blocks are code blocks.
             const [match] = Editor.nodes(editor, {
-              match: n => n.type === 'code',
+              match: n => Element.isElement(n) && n.type === 'code',
             })
             // Toggle the block type depending on whether there's already a match.
             Transforms.setNodes(


### PR DESCRIPTION
**Description**
A clear and concise description of what this pull request solves. (Please do not just link to a long issue thread. Instead include a clear description here or your pull request will likely not be reviewed as quickly.)
Cannot run the code of walkthrough: Defining custom element. There is an error for code:
`const [match] = Editor.nodes(editor, {
  match: n => n.type === 'code',
})`
error message:
Property 'type' does not exist on type 'Node'. Property 'type' does not exist on type 'CustomText'.
**Issue**
Fixes: (link to issue)
no issue link

**Example**
A GIF or video showing the old and new behaviors after this pull request is merged. Or a code sample showing the usage of a new API. (If you don't include this, your pull request will not be reviewed as quickly, because it's much too hard to figure out exactly what is going wrong, and it makes maintenance much harder.)
please see description

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [yes] The new code matches the existing patterns and styles.
- [yes] The tests pass with `yarn test`.
- [yes] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [yes] The relevant examples still work. (Run examples with `yarn start`.)
- [no need to do] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

